### PR TITLE
Fixed ofe functions

### DIFF
--- a/R/OFE_rotate_and_grid.R
+++ b/R/OFE_rotate_and_grid.R
@@ -167,7 +167,6 @@ ofe_grid_data <- function(data_in, rotation_angle, nrow, npe, ncol, trim_ends=TR
     max(data_pre_angle$x)+x_gap/2,
     length=(ncol+1)
   )
-  col_mid_points <- col_breaks[1:ncol] + diff(col_breaks)
   for (i in 1:ncol){
     data_pre_angle$Col <- data_pre_angle$Col + (data_pre_angle$x>col_breaks[i])
   }

--- a/R/OFE_rotate_and_grid.R
+++ b/R/OFE_rotate_and_grid.R
@@ -252,7 +252,7 @@ ofe_grid_data <- function(data_in, rotation_angle, nrow, npe, ncol, trim_ends=TR
       temp_filter = paste(Row, Col)
     )
   
-  point.reference.frame <- data.frame(
+  point_reference_frame <- data.frame(
     Row = as.factor(rep(1:nrow, ncol)),
     Col = as.factor(rep(1:ncol, each = nrow))
   ) |> 
@@ -278,11 +278,11 @@ ofe_grid_data <- function(data_in, rotation_angle, nrow, npe, ncol, trim_ends=TR
   structure(
     class = "gridded.ofe",
     list(
-      gridded_data = point.reference.frame |> 
+      gridded_data = point_reference_frame |> 
         dplyr::left_join(data_out_summary) |>
         dplyr::select(-temp_filter) |> 
         dplyr::mutate(
-          Pe.Row = as.factor(1 + floor(npe*as.numeric(Row)/(nrow+1e-6)))
+          Pe = as.factor(1 + floor(npe*as.numeric(Row)/(nrow+1e-6)))
         ) |>
         dplyr::arrange(Rep, Col, Row),
       original_data = data_out

--- a/R/OFE_rotate_and_grid.R
+++ b/R/OFE_rotate_and_grid.R
@@ -47,7 +47,11 @@ ofe_rotate_data <- function(data, angle){
   ), nrow=2, ncol=2)
   
   original_coordinates <- sf::st_coordinates(data)
-  translation_matrix <- apply(st_coordinates(data), 2, mean)
+  translation_matrix <- apply(
+    original_coordinates,
+    2,
+    function(x){(max(x)+min(x))/2}
+  )
   
   rotated_coordinates <- (
     rotation_matrix %*% (
@@ -241,15 +245,12 @@ ofe_grid_data <- function(data_in, rotation_angle, nrow, npe, ncol, trim_ends=TR
     ) |>
     dplyr::group_by(Col, Row) |>
     dplyr::summarise(
-      Yield = mean(Yield),
-      Treatment = dplyr::first(Treatment),
-      Rep = dplyr::first(Rep)
+      Yield = mean(Yield)
     ) |>
     as.data.frame() |>
     dplyr::mutate(
       temp_filter = paste(Row, Col)
-    ) |>
-    dplyr::arrange(Rep, Col, Row)
+    )
   
   point.reference.frame <- data.frame(
     Row = as.factor(rep(1:nrow, ncol)),
@@ -260,6 +261,16 @@ ofe_grid_data <- function(data_in, rotation_angle, nrow, npe, ncol, trim_ends=TR
       y = row_mid_points[Row],
       x_rotated = col_mid_points[Col]-col_mid_points[1],
       y_rotated = row_mid_points[Row]-row_mid_points[1]
+    ) |> 
+    left_join(
+      data_out |> 
+        sf::st_drop_geometry() |> 
+        dplyr::mutate(Col = as.factor(Col)) |> 
+        dplyr::group_by(Col) |> 
+        dplyr::summarise(
+          Treatment = dplyr::first(Treatment),
+          Rep = dplyr::first(Rep)
+        )
     ) |> 
     sf::st_as_sf(coords = c("x", "y"), crs = sf::st_crs(data)) |> 
     ofe_rotate_data(-true_angle)
@@ -272,7 +283,8 @@ ofe_grid_data <- function(data_in, rotation_angle, nrow, npe, ncol, trim_ends=TR
         dplyr::select(-temp_filter) |> 
         dplyr::mutate(
           Pe.Row = as.factor(1 + floor(npe*as.numeric(Row)/(nrow+1e-6)))
-        ),
+        ) |>
+        dplyr::arrange(Rep, Col, Row),
       original_data = data_out
     )
   )


### PR DESCRIPTION
It took all of an hour to find multiple issues (thank you Matt!)
- Fixed error in **ofe_rotate_data** caused by not explicitly using sf when calling sf::st_coordinates()
- Adjusted center of rotation to use the extrema of the data rather than the mean which would be influenced by missing data.
- Adjusted **ofe_grid_data** to correctly allocate Rep and Treatment to NA values in a strip with known Rep and Treatment. Previous version would set these to NA as well, which would not allow ASReml to build models.